### PR TITLE
Fix various things & add support for precommands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sL -o restic.tar.gz https://github.com/restic/restic/releases/download
 #
 FROM alpine:3.9
 
-RUN apk add --update --no-cache ca-certificates fuse nfs-utils openssh
+RUN apk add --update --no-cache ca-certificates fuse nfs-utils openssh tzdata
 
 ENV RESTIC_REPOSITORY /mnt/restic
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -sL -o restic.tar.gz https://github.com/restic/restic/releases/download
 #
 # Final image
 #
-FROM alpine:3.9
+FROM alpine:3.10
 
 RUN apk add --update --no-cache ca-certificates fuse nfs-utils openssh tzdata bash
 RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community/ docker-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN curl -sL -o restic.tar.gz https://github.com/restic/restic/releases/download
 #
 FROM alpine:3.9
 
-RUN apk add --update --no-cache ca-certificates fuse nfs-utils openssh tzdata
+RUN apk add --update --no-cache ca-certificates fuse nfs-utils openssh tzdata bash
+RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community/ docker-cli
 
 ENV RESTIC_REPOSITORY /mnt/restic
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Builder image
 #
-FROM golang AS builder
+FROM golang:1.12 AS builder
 
 ARG RESTIC_VERSION=0.9.5
 ARG RESTIC_SHA256=e22208e946ede07f56ef60c1c89de817b453967663ce4867628dff77761bd429

--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ E.g.
 * `RESTIC_BACKUP_TAGS` - Optional. Tags to set on each snapshot, separated by commas. E.g. `swarm,docker-volumes`
 * `RESTIC_FORGET_ARGS` - Optional. If specified `restic forget` is run with the given arguments after each backup. E.g. `--prune --keep-last 14 --keep-daily 1`
 * (Additional variables as needed for the chosen backup target. E.g. `B2_ACCOUNT_ID` and `B2_ACCOUNT_KEY` for Backblaze B2.)
+* `TZ` - Optional. Set your timezone for the correct cron execution time.
+
+## Execute commands prior to backup
+
+It's possible to optionally execute commands (like database dumps) before the actual backup starts. If you want to execute `docker` commands on the host, mount the Docker socket to the container. To do that add the following volume to the compose or swarm configuration:
+
+    - /var/run/docker.sock:/var/run/docker.sock
+
+You can add one or multiple commands by specifying the following environment variable:
+
+    PRE_COMMANDS: |-
+                docker exec nextcloud-postgres pg_dumpall -U nextcloud -f /data/nextcloud.sql
+                docker exec other-postgres pg_dumpall -U other -f /data/other.sql
+
+The commands specified in `PRE_COMMANDS` are executed one by one.
 
 ## Build instructions
 

--- a/backup
+++ b/backup
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -eo pipefail
 
+PRE_COMMANDS="${PRE_COMMANDS:-}"
+while IFS= read -r cmd; do echo $cmd && eval $cmd ; done < <(printf '%s\n' "$PRE_COMMANDS")
+
 RESTIC_BACKUP_SOURCES=${RESTIC_BACKUP_SOURCES:-/data}
 RESTIC_BACKUP_TAGS="${RESTIC_BACKUP_TAGS:-}"
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -13,5 +13,6 @@ services:
       RESTIC_FORGET_ARGS: --prune --keep-last 14 --keep-daily 1
       B2_ACCOUNT_ID: xxxxxxx
       B2_ACCOUNT_KEY: yyyyyyyy
+      TZ: Europe/Berlin
     volumes:
       - /var/lib/docker/volumes:/mnt/volumes:ro

--- a/docker-swarm.example.yml
+++ b/docker-swarm.example.yml
@@ -12,7 +12,7 @@ services:
       RESTIC_FORGET_ARGS: --prune --keep-last 14 --keep-daily 1
       B2_ACCOUNT_ID: xxxxxxx
       B2_ACCOUNT_KEY: yyyyyyyy
-      TZ: Europa/Berlin
+      TZ: Europe/Berlin
     hostname: "{{.Node.ID}}"
     volumes:
       - /var/lib/docker/volumes:/mnt/volumes:ro

--- a/docker-swarm.example.yml
+++ b/docker-swarm.example.yml
@@ -12,6 +12,7 @@ services:
       RESTIC_FORGET_ARGS: --prune --keep-last 14 --keep-daily 1
       B2_ACCOUNT_ID: xxxxxxx
       B2_ACCOUNT_KEY: yyyyyyyy
+      TZ: Europa/Berlin
     hostname: "{{.Node.ID}}"
     volumes:
       - /var/lib/docker/volumes:/mnt/volumes:ro


### PR DESCRIPTION
This PR has the following changes:

- Use specific go version in Dockerfile (in case anything should break in future versions)
- Add tzdata package (to be able to set the correct time zone using the TZ env variable)
- Add support for "pre-commands", so one can execute commands before the backup actually starts. For this bash and docker-cli are added. When mounting the docker socket it's possible to execute commands in other containers. That's probably not Docker best practices, but I was inspired by my old backup solution which had support for something similar to this (https://github.com/blacklabelops/volumerize/).