### PR TITLE
Support `rclone`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG RESTIC_VERSION=0.9.5
 ARG RESTIC_SHA256=e22208e946ede07f56ef60c1c89de817b453967663ce4867628dff77761bd429
 ARG GO_CRON_VERSION=0.0.2
 ARG GO_CRON_SHA256=ca2acebf00d61cede248b6ffa8dcb1ef5bb92e7921acff3f9d6f232f0b6cf67a
-ARG RCLONE_VERISON=1.49.5
+ARG RCLONE_VERSION=1.49.5
 ARG RCLONE_SHA256=7922455f95e8e71f9e484f84ac3ae015379e65ccc3f7d93d804fc0a76515c973
 
 RUN curl -sL -o go-cron.tar.gz https://github.com/michaloo/go-cron/archive/v${GO_CRON_VERSION}.tar.gz \
@@ -30,12 +30,12 @@ RUN curl -sL -o restic.tar.gz https://github.com/restic/restic/releases/download
  && cd .. \
  && rm restic.tar.gz restic-${RESTIC_VERSION} -fR
 
-RUN curl -sL -o rclone.zip https://downloads.rclone.org/v${RCLONE_VERISON}/rclone-v${RCLONE_VERISON}-linux-amd64.zip \
+RUN curl -sL -o rclone.zip https://downloads.rclone.org/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-amd64.zip \
  && echo "${RCLONE_SHA256}  rclone.zip" | sha256sum -c - \
  && apt-get update -qq \
  && apt-get install -yq unzip \
  && unzip -a rclone.zip \
- && mv rclone-v${RCLONE_VERISON}-linux-amd64/rclone /usr/local/bin/rclone
+ && mv rclone-v${RCLONE_VERSION}-linux-amd64/rclone /usr/local/bin/rclone
 
 #
 # Final image

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ ARG RESTIC_SHA256=e22208e946ede07f56ef60c1c89de817b453967663ce4867628dff77761bd4
 ARG GO_CRON_VERSION=0.0.2
 ARG GO_CRON_SHA256=ca2acebf00d61cede248b6ffa8dcb1ef5bb92e7921acff3f9d6f232f0b6cf67a
 
+RUN apt-get update -qq \
+ && apt-get install -yq unzip
+
 RUN curl -sL -o go-cron.tar.gz https://github.com/michaloo/go-cron/archive/v${GO_CRON_VERSION}.tar.gz \
  && echo "${GO_CRON_SHA256}  go-cron.tar.gz" | sha256sum -c - \
  && tar xzf go-cron.tar.gz \
@@ -27,6 +30,10 @@ RUN curl -sL -o restic.tar.gz https://github.com/restic/restic/releases/download
  && mv restic /usr/local/bin/restic \
  && cd .. \
  && rm restic.tar.gz restic-${RESTIC_VERSION} -fR
+
+RUN curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip \
+ && unzip -a rclone-current-linux-amd64.zip \
+ && mv rclone-*/rclone /usr/local/bin/rclone
 
 #
 # Final image

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,8 @@ ARG RESTIC_VERSION=0.9.5
 ARG RESTIC_SHA256=e22208e946ede07f56ef60c1c89de817b453967663ce4867628dff77761bd429
 ARG GO_CRON_VERSION=0.0.2
 ARG GO_CRON_SHA256=ca2acebf00d61cede248b6ffa8dcb1ef5bb92e7921acff3f9d6f232f0b6cf67a
-
-RUN apt-get update -qq \
- && apt-get install -yq unzip
+ARG RCLONE_VERISON=1.49.5
+ARG RCLONE_SHA256=7922455f95e8e71f9e484f84ac3ae015379e65ccc3f7d93d804fc0a76515c973
 
 RUN curl -sL -o go-cron.tar.gz https://github.com/michaloo/go-cron/archive/v${GO_CRON_VERSION}.tar.gz \
  && echo "${GO_CRON_SHA256}  go-cron.tar.gz" | sha256sum -c - \
@@ -31,9 +30,12 @@ RUN curl -sL -o restic.tar.gz https://github.com/restic/restic/releases/download
  && cd .. \
  && rm restic.tar.gz restic-${RESTIC_VERSION} -fR
 
-RUN curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip \
- && unzip -a rclone-current-linux-amd64.zip \
- && mv rclone-*/rclone /usr/local/bin/rclone
+RUN curl -sL -o rclone.zip https://downloads.rclone.org/v${RCLONE_VERISON}/rclone-v${RCLONE_VERISON}-linux-amd64.zip \
+ && echo "${RCLONE_SHA256}  rclone.zip" | sha256sum -c - \
+ && apt-get update -qq \
+ && apt-get install -yq unzip \
+ && unzip -a rclone.zip \
+ && mv rclone-v${RCLONE_VERISON}-linux-amd64/rclone /usr/local/bin/rclone
 
 #
 # Final image

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ E.g.
 ## Configuration options
 
 * `BACKUP_CRON` - A cron expression for when to run the backup. E.g. `0 30 3 * * *` in order to run every night at 3:30 am. See [the go-cron documentation](https://godoc.org/github.com/robfig/cron) for details on the expression format
-* `RESTIC_REPOSITORY` - location of the restic repository. You can use [any target supported by restic](https://restic.readthedocs.io/en/stable/manual.html#initialize-a-repository). Default `/mnt/restic`
+* `RESTIC_REPOSITORY` - location of the restic repository. You can use [any target supported by restic](https://restic.readthedocs.io/en/stable/030_preparing_a_new_repo.html). Default `/mnt/restic`
 * `RESTIC_BACKUP_SOURCES` - source directory to backup. Make sure to mount this into the container as a volume (see the example configs). Default `/data`
 * `RESTIC_PASSWORD` - password for the restic repository. Will also be used to initialize the repository if it is not yet initialized
 * `RESTIC_BACKUP_TAGS` - Optional. Tags to set on each snapshot, separated by commas. E.g. `swarm,docker-volumes`
@@ -66,6 +66,10 @@ You can add one or multiple commands by specifying the following environment var
                 docker exec other-postgres pg_dumpall -U other -f /data/other.sql
 
 The commands specified in `PRE_COMMANDS` are executed one by one.
+
+## Using `rclone` repository type
+
+In order to use `rclone` repository type, you need to prepare a `rclone.conf` file and mount it inside the container to `/root/.config/rclone/rclone.conf`.
 
 ## Build instructions
 


### PR DESCRIPTION
Because I have to use FTP (yeah...)

`rclone` has to be present in the image, and config needs to be mounted to actually use it.

Tested (with lines 4-5 of `backup` commented out because of #4), works well 🙂 