### PR TITLE
Post commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ E.g.
 
 ## Execute commands prior to backup
 
-It's possible to optionally execute commands (like database dumps) before the actual backup starts. If you want to execute `docker` commands on the host, mount the Docker socket to the container. To do that add the following volume to the compose or swarm configuration:
+It's possible to optionally execute commands (like database dumps, or stopping a running container to avoid inconsistent backup data) before the actual backup starts. If you want to execute `docker` commands on the host, mount the Docker socket to the container. To do that add the following volume to the compose or swarm configuration:
 
     - /var/run/docker.sock:/var/run/docker.sock
 
@@ -64,8 +64,30 @@ You can add one or multiple commands by specifying the following environment var
     PRE_COMMANDS: |-
                 docker exec nextcloud-postgres pg_dumpall -U nextcloud -f /data/nextcloud.sql
                 docker exec other-postgres pg_dumpall -U other -f /data/other.sql
+		docker stop my_container
 
 The commands specified in `PRE_COMMANDS` are executed one by one.
+
+## Execute commands prior to backup
+
+It's possible to optionally execute commands (like restarting a temporarily stopped container, send a mail...) once the actual backup has finished. Like for pre-backup copmands, if you want to execute `docker` commands on the host, mount the Docker socket to the container.
+
+You can add one or multiple commands by specifying the following environment variables:
+
+    POST_COMMANDS_SUCCESS: |-
+		/my/scripts/mail-success.sh
+
+    POST_COMMANDS_FAILURE: |-
+		/my/scripts/mail-failure.sh
+
+    POST_COMMANDS_EXIT: |-
+		docker start my_container
+
+The commands specified are executed one by one.
+POST_COMMANDS_SUCCESS commands will be executed after a successful backup run.
+POST_COMMANDS_FAILURE commande will be executed after a failed backup run.
+POST_COMMANDS_EXIT will always be executed, after both successful or failed backup runs.
+
 
 ## Build instructions
 

--- a/backup
+++ b/backup
@@ -2,13 +2,19 @@
 set -eo pipefail
 
 function run_commands {
-	COMMANDS="${!1:-}"
+	COMMANDS=$1
 	while IFS= read -r cmd; do echo $cmd && eval $cmd ; done < <(printf '%s\n' "$COMMANDS")
 }
 
-trap "run_commands POST_COMMANDS_EXIT" EXIT
+function run_exit_commands {
+	set +e
+	set +o pipefail
+	run_commands "${POST_COMMANDS_EXIT:-}"
+}
 
-run_commands PRE_COMMANDS
+trap run_exit_commands EXIT
+
+run_commands "${PRE_COMMANDS:-}"
 
 RESTIC_BACKUP_SOURCES=${RESTIC_BACKUP_SOURCES:-/data}
 RESTIC_BACKUP_TAGS="${RESTIC_BACKUP_TAGS:-}"
@@ -23,11 +29,11 @@ start=`date +%s`
 echo Starting Backup at $(date +"%Y-%m-%d %H:%M:%S")
 
 set +e
-restic backup ${tag_options} ${RESTIC_BACKUP_SOURCES} 
+restic backup ${tag_options} ${RESTIC_BACKUP_SOURCES}
 if [ $? -ne 0 ]
 then
 	set -e
-	run_commands POST_COMMANDS_FAILURE
+	run_commands "${POST_COMMANDS_FAILURE:-}"
 	exit
 else
 	set -e
@@ -43,4 +49,4 @@ fi
 end=`date +%s`
 echo Finished backup at $(date +"%Y-%m-%d %H:%M:%S") after $((end-start)) seconds
 
-run_commands POST_COMMANDS_SUCCESS
+run_commands "${POST_COMMANDS_SUCCESS:-}"

--- a/backup
+++ b/backup
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -eo pipefail
 
 PRE_COMMANDS="${PRE_COMMANDS:-}"

--- a/backup
+++ b/backup
@@ -1,8 +1,14 @@
 #!/bin/bash
 set -eo pipefail
 
-PRE_COMMANDS="${PRE_COMMANDS:-}"
-while IFS= read -r cmd; do echo $cmd && eval $cmd ; done < <(printf '%s\n' "$PRE_COMMANDS")
+function run_commands {
+	COMMANDS="${!1:-}"
+	while IFS= read -r cmd; do echo $cmd && eval $cmd ; done < <(printf '%s\n' "$COMMANDS")
+}
+
+trap "run_commands POST_COMMANDS_EXIT" EXIT
+
+run_commands PRE_COMMANDS
 
 RESTIC_BACKUP_SOURCES=${RESTIC_BACKUP_SOURCES:-/data}
 RESTIC_BACKUP_TAGS="${RESTIC_BACKUP_TAGS:-}"
@@ -16,7 +22,16 @@ done
 start=`date +%s`
 echo Starting Backup at $(date +"%Y-%m-%d %H:%M:%S")
 
-restic backup ${tag_options} ${RESTIC_BACKUP_SOURCES}
+set +e
+restic backup ${tag_options} ${RESTIC_BACKUP_SOURCES} 
+if [ $? -ne 0 ]
+then
+	set -e
+	run_commands POST_COMMANDS_FAILURE
+	exit
+else
+	set -e
+fi
 
 echo Backup successful
 
@@ -27,3 +42,5 @@ fi
 
 end=`date +%s`
 echo Finished backup at $(date +"%Y-%m-%d %H:%M:%S") after $((end-start)) seconds
+
+run_commands POST_COMMANDS_SUCCESS


### PR DESCRIPTION
New environment variables for post-commands.
It can be useful for restarting a container stopped with pre-commands, or notifying of success/failure.

3 sets of commands:
- for successful backups,
- for failed backups,
- commands that will be executed in all cases at the end of the scheduled execution - typically, restarting stopped containers.