### PR TITLE
Feature : Add curl to final image (for Slack webhook)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN curl -sL -o restic.tar.gz https://github.com/restic/restic/releases/download
 #
 FROM alpine:3.10
 
-RUN apk add --update --no-cache ca-certificates fuse nfs-utils openssh tzdata bash
+RUN apk add --update --no-cache ca-certificates fuse nfs-utils openssh tzdata bash curl
 RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community/ docker-cli
 
 ENV RESTIC_REPOSITORY /mnt/restic


### PR DESCRIPTION
According to [slack documentation](https://api.slack.com/tutorials/slack-apps-hello-world). The integration of curl in the final image would allow immediate use of webhooks in the POST_COMMANDS_XXXXX.

Example :  
`curl -X POST -H 'Content-type: application/json' --data '{"text":"Allow me to reintroduce myself!"}' YOUR_WEBHOOK_URL`

It is completely optional, but very handy... :)