### PR TITLE
Add better docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Run automatic [restic](https://restic.github.io/) backups via a Docker container
 
 * run scheduled backups
 * backup to any (local or remote) target supported by restic
-* add custom tags to backups
+* support for tags, exclude definitions, and all other optional restic options
 * automatic forgetting of old backups
 * prune backups on a schedule
 * can be used as a (global) Docker swarm service in order to backup every cluster node
@@ -62,15 +62,15 @@ E.g.
 
 *Note: `BACKUP_CRON` and `PRUNE_CRON` are mutually exclusive.*
 
-* `BACKUP_CRON`- A cron expression for when to run the backup. E.g. `0 30 3 * * *` in order to run every night at 3:30 am. See [the go-cron documentation](https://godoc.org/github.com/robfig/cron) for details on the expression format
+* `BACKUP_CRON` - A cron expression for when to run the backup. E.g. `0 30 3 * * *` in order to run every night at 3:30 am. See [the go-cron documentation](https://godoc.org/github.com/robfig/cron) for details on the expression format
 * `PRUNE_CRON` - A cron expression for when to run the prune job. E.g. `0 0 4 * * *` in order to run every night at 4:00 am. See [the go-cron documentation](https://godoc.org/github.com/robfig/cron) for details on the expression format
 * `RESTIC_REPOSITORY` - location of the restic repository. You can use [any target supported by restic](https://restic.readthedocs.io/en/stable/030_preparing_a_new_repo.html). Default `/mnt/restic`
 * `RESTIC_BACKUP_SOURCES` - source directory to backup. Make sure to mount this into the container as a volume (see the example configs). Default `/data`
 * `RESTIC_PASSWORD` - password for the restic repository. Will also be used to initialize the repository if it is not yet initialized
-* `RESTIC_BACKUP_ARGS` - Optional. Additional arguments given to *restic backup*.
-* `RESTIC_BACKUP_TAGS` - Optional. Tags to set on each snapshot, separated by commas. E.g. `swarm,docker-volumes`
-* `RESTIC_FORGET_ARGS` - Optional. If specified `restic forget` is run with the given arguments after each backup. E.g. `--prune --keep-last 14 --keep-daily 1`
-* (Additional variables as needed for the chosen backup target. E.g. `B2_ACCOUNT_ID` and `B2_ACCOUNT_KEY` for Backblaze B2.)
+* `RESTIC_BACKUP_ARGS` - If specified `restic backup` is run with the given arguments, e.g. for tags, exclude definitions, or verbose logging: `--tag docker-volumes --exclude-file='exclude.txt' --verbose`. See the [restic backup documentation](https://restic.readthedocs.io/en/stable/040_backup.html) for available options
+* `RESTIC_BACKUP_TAGS` - *Deprecated*. Tags to set for each snapshot, separated by commas. This option will soon be removed. Please use `RESTIC_BACKUP_ARGS` to define tags.
+* `RESTIC_FORGET_ARGS` - If specified `restic forget` is run with the given arguments after each backup, e.g. `--prune --keep-last 14 --keep-daily 1`. See the [restic forget documentation](https://restic.readthedocs.io/en/stable/060_forget.html) for available options
+* (Additional variables as needed for the chosen backup target. E.g. `B2_ACCOUNT_ID` and `B2_ACCOUNT_KEY` for Backblaze B2. See official restic documentation about [supported environment variables](https://restic.readthedocs.io/en/stable/040_backup.html#environment-variables).)
 * `TZ` - Optional. Set your timezone for the correct cron execution time.
 
 ### Using `rclone` repository type

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -9,9 +9,16 @@ services:
       RESTIC_REPOSITORY: b2:my-repo:/restic
       RESTIC_PASSWORD: supersecret
       RESTIC_BACKUP_SOURCES: /mnt/volumes
-      #RESTIC_BACKUP_ARGS: -v
-      RESTIC_BACKUP_TAGS: docker-volumes
-      RESTIC_FORGET_ARGS: --prune --keep-last 14 --keep-daily 1
+      RESTIC_BACKUP_ARGS: >-
+        --tag docker-volumes
+        --exclude='some-folder/cache'
+        --exclude='*.tmp'
+        --verbose
+      RESTIC_FORGET_ARGS: >-
+        --keep-last 10
+        --keep-daily 7
+        --keep-weekly 5
+        --keep-monthly 12
       B2_ACCOUNT_ID: xxxxxxx
       B2_ACCOUNT_KEY: yyyyyyyy
       TZ: Europe/Berlin


### PR DESCRIPTION
Hey!
Went a bit back and forth on this. My intention was to make the use of excludes as useful as possible, for me and other users. I started by adding a new env but realized that the right use of multiline yaml is all that is needed.

The change highlights the right use of multiline for backup args and gives a better forget example.

The PR also introduces BACKUP_ARGS as a way to pass tags. Imho this is the better way to offer this option in the long run. For now no real changes in this regard - if you are willing to consider it I would suggest to gradually deprecate `RESTIC_BACKUP_TAGS` in favor of the more versatile `RESTIC_FORGET_ARGS`.

Best! th