### PR TITLE
Fix unbound variable

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -16,7 +16,7 @@ else
     >&2 echo "Environment variables BACKUP_CRON and PRUNE_CRON are mutually exclusive. Please fix your configuration. Exiting."
     exit 1
   if [[ -n "${BACKUP_CRON:-}" ]]; then
-    if [ "${RUN_ON_STARTUP}" == "true" ]; then
+    if [ "${RUN_ON_STARTUP:-}" == "true" ]; then
       echo "Executing backup on startup ..."
       /usr/local/bin/backup
     fi
@@ -24,7 +24,7 @@ else
     exec go-cron "$BACKUP_CRON" /usr/local/bin/backup
   fi
   if [[ -n "${PRUNE_CRON:-}" ]]; then
-    if [ "${RUN_ON_STARTUP}" == "true" ]; then
+    if [ "${RUN_ON_STARTUP:-}" == "true" ]; then
       echo "Executing prune job on startup ..."
       /usr/local/bin/prune
     fi


### PR DESCRIPTION
Allows for not specifying `RUN_ON_STARTUP`. Seems like the other variables had it (besides `RESTIC_REPOSITORY` of course).