### PR TITLE
Replace repository checking logic

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -10,9 +10,9 @@ else
     echo "Repository successfully initialized."
   else
     if [ "${SKIP_INIT_CHECK:-}" == "true" ]; then
-      echo "Ignoring initialization errors because SKIP_INIT_CHECK is set in your configuration."
+      echo "Initialization failed. Ignoring errors because SKIP_INIT_CHECK is set in your configuration."
     else
-      echo "Initialization failed. Please check error messages above and check your configuration. Exiting."
+      echo "Initialization failed. Please see error messages above and check your configuration. Exiting."
       exit 1
     fi
   fi

--- a/entrypoint
+++ b/entrypoint
@@ -1,13 +1,23 @@
 #!/bin/bash
 set -euo pipefail
 
-if [ -z "${RESTIC_REPOSITORY##*:*}" ]; then
-  echo "Trying to initialize remote repository '${RESTIC_REPOSITORY}' (in case it has not been initialized yet)"
-  restic init || true
-elif [ ! -f "$RESTIC_REPOSITORY/config" ]; then
-  echo "Restic repository '${RESTIC_REPOSITORY}' does not exist. Running restic init"
-  restic init
+echo "Checking configured repository '${RESTIC_REPOSITORY}' ..."
+if restic cat config > /dev/null; then
+  echo "Repository found."
+else
+  echo "Could not access the configured repository. Trying to initialize (in case it has not been initialized yet) ..."
+  if restic init; then
+    echo "Repository successfully initialized."
+  else
+    if [ "${SKIP_INIT_CHECK:-}" == "true" ]; then
+      echo "Ignoring initialization errors because SKIP_INIT_CHECK is set in your configuration."
+    else
+      echo "Initialization failed. Please check error messages above and check your configuration. Exiting."
+      exit 1
+    fi
+  fi
 fi
+echo -e "\n"
 
 if [[ $# -gt 0 ]]; then
   exec restic "$@"


### PR DESCRIPTION
Closes #37 

I believe this covers everything the old code caught. It's not much logic besides a lot of logging. Decision to go with `cat config` follows https://github.com/restic/restic/issues/1690#issuecomment-620197338 - we should watch out for a "check" command implemented in the future.

Major change: So far the initial check could have failed and the backup would still have been scheduled. Now if the check does not succeed the container will fail during initialization.

Quick words about `SKIP_INIT_CHECK`: I intentionally did not document this variable. It shouldn't be a feature but rather a workaround for users with serious reasons to resort to it. Also, if after this PR is merged a user complains about issues, the variable can serve as a 0-day fix before we understand the needed improvement.