### PR TITLE
Explain prune job and add better example times

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -31,7 +31,7 @@ services:
     hostname: docker
     environment:
       RUN_ON_STARTUP: "true"
-      PRUNE_CRON: "0 0 4 * * *"
+      PRUNE_CRON: "0 30 15 * * *"
       RESTIC_REPOSITORY: b2:my-repo:/restic
       RESTIC_PASSWORD: supersecret
       B2_ACCOUNT_ID: xxxxxxx


### PR DESCRIPTION
Ref: https://github.com/djmaze/resticker/issues/48#issuecomment-647105878

If a user decides to configure the prune job independently from the backup job, giving the backup job 30min to finish might not be enough. Obviously this is up the user to decide and configure.

I suggest to improve the documentation:

[x] Update compose example
[ ] Update swarm example
[ ] Update example in `PRUNE_CRON` documentation
[ ] Add section about prune service rationale