### PR TITLE
Different amount of parameters in cron-examples when compared with go-cron docu

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ E.g.
 
 *Note: `BACKUP_CRON` and `PRUNE_CRON` are mutually exclusive.*
 
-* `BACKUP_CRON` - A cron expression for when to run the backup. E.g. `0 30 3 * * *` in order to run every night at 3:30 am. See [the go-cron documentation](https://godoc.org/github.com/robfig/cron) for details on the expression format
-* `PRUNE_CRON` - A cron expression for when to run the prune job. E.g. `0 0 4 * * *` in order to run every night at 4:00 am. See [the go-cron documentation](https://godoc.org/github.com/robfig/cron) for details on the expression format
+* `BACKUP_CRON` - A cron expression for when to run the backup. E.g. `30 3 * * *` in order to run every night at 3:30 am. See [the go-cron documentation](https://godoc.org/github.com/robfig/cron) for details on the expression format
+* `PRUNE_CRON` - A cron expression for when to run the prune job. E.g. `0 4 * * *` in order to run every night at 4:00 am. See [the go-cron documentation](https://godoc.org/github.com/robfig/cron) for details on the expression format
 * `RUN_ON_STARTUP` - Set to `"true"` to execute a backup or prune job right on startup, in addition to the given cron expression. Disabled by default
 * `RESTIC_REPOSITORY` - Location of the restic repository. You can use [any target supported by restic](https://restic.readthedocs.io/en/stable/030_preparing_a_new_repo.html). Default `/mnt/restic`
 * `RESTIC_BACKUP_SOURCES` - Source directory to backup. Make sure to mount this into the container as a volume (see the example configs). Default `/data`

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -6,7 +6,7 @@ services:
     hostname: docker
     environment:
       RUN_ON_STARTUP: "true"
-      BACKUP_CRON: "0 30 3 * * *"
+      BACKUP_CRON: "30 3 * * *"
       RESTIC_REPOSITORY: b2:my-repo:/restic
       RESTIC_PASSWORD: supersecret
       RESTIC_BACKUP_SOURCES: /mnt/volumes
@@ -31,7 +31,7 @@ services:
     hostname: docker
     environment:
       RUN_ON_STARTUP: "true"
-      PRUNE_CRON: "0 0 4 * * *"
+      PRUNE_CRON: "0 4 * * *"
       RESTIC_REPOSITORY: b2:my-repo:/restic
       RESTIC_PASSWORD: supersecret
       B2_ACCOUNT_ID: xxxxxxx

--- a/docker-swarm.example.yml
+++ b/docker-swarm.example.yml
@@ -4,7 +4,7 @@ services:
   backup:
     image: mazzolino/restic
     environment:
-      BACKUP_CRON: "0 30 3 * * *"
+      BACKUP_CRON: "30 3 * * *"
       RESTIC_REPOSITORY: b2:my-repo:/restic
       RESTIC_PASSWORD: supersecret
       RESTIC_BACKUP_SOURCES: /mnt/volumes
@@ -24,7 +24,7 @@ services:
     image: mazzolino/restic
     hostname: docker
     environment:
-      PRUNE_CRON: "0 0 4 * * *"
+      PRUNE_CRON: "0 4 * * *"
       RESTIC_REPOSITORY: b2:my-repo:/restic
       RESTIC_PASSWORD: supersecret
       B2_ACCOUNT_ID: xxxxxxx


### PR DESCRIPTION
In the cron examples within Readme and deploy-files are currently 6 parameters. According to the go-cron documentation (linked in Readme) there should only be five parameters.

If I made a mistake please reject this pull request. Maybe I have overseen something.

PS: Thank you for the development of this docker image :-)