### PR TITLE
Switch to using the provided binaries instead of building everything from source 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,6 +12,8 @@ steps:
     settings:
       auto_tag: true
       auto_tag_suffix: amd64
+      build_args:
+        ARCH: ${DRONE_STAGE_ARCH}
       repo: mazzolino/restic
       username:
         from_secret: docker_username
@@ -29,6 +31,8 @@ steps:
   - name: build branch
     image: plugins/docker
     settings:
+      build_args:
+        ARCH: ${DRONE_STAGE_ARCH}     
       repo: mazzolino/restic-test
       tags: ${DRONE_BRANCH}-amd64
       username:
@@ -47,6 +51,8 @@ steps:
   - name: build pr
     image: plugins/docker
     settings:
+      build_args:
+        ARCH: ${DRONE_STAGE_ARCH}   
       repo: mazzolino/restic-test
       tags: pr-${DRONE_PULL_REQUEST}-amd64
       username:
@@ -69,6 +75,8 @@ steps:
   - name: build release
     image: plugins/docker:linux-arm
     settings:
+      build_args:
+        ARCH: ${DRONE_STAGE_ARCH}
       auto_tag: true
       auto_tag_suffix: arm
       repo: mazzolino/restic
@@ -88,6 +96,8 @@ steps:
   - name: build branch
     image: plugins/docker:linux-arm
     settings:
+      build_args:
+        ARCH: ${DRONE_STAGE_ARCH} 
       repo: mazzolino/restic-test
       tags: ${DRONE_BRANCH}-arm
       username:
@@ -106,6 +116,8 @@ steps:
   - name: build pr
     image: plugins/docker:linux-arm
     settings:
+      build_args:
+        ARCH: ${DRONE_STAGE_ARCH}
       repo: mazzolino/restic-test
       tags: pr-${DRONE_PULL_REQUEST}-arm
       username:
@@ -130,6 +142,8 @@ steps:
     settings:
       auto_tag: true
       auto_tag_suffix: arm64
+      build_args:
+        ARCH: ${DRONE_STAGE_ARCH} 
       repo: mazzolino/restic
       username:
         from_secret: docker_username
@@ -147,6 +161,8 @@ steps:
   - name: build branch
     image: plugins/docker:linux-arm64
     settings:
+      build_args:
+        ARCH: ${DRONE_STAGE_ARCH}
       repo: mazzolino/restic-test
       tags: ${DRONE_BRANCH}-arm64
       username:
@@ -165,6 +181,8 @@ steps:
   - name: build pr
     image: plugins/docker:linux-arm64
     settings:
+      build_args:
+        ARCH: ${DRONE_STAGE_ARCH}  
       repo: mazzolino/restic-test
       tags: pr-${DRONE_PULL_REQUEST}-arm64
       username:

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,11 +9,13 @@ platform:
 steps:
   - name: build release
     image: plugins/docker
+    environment:
+      ARCH: amd64
     settings:
       auto_tag: true
       auto_tag_suffix: amd64
-      build_args:
-        ARCH: ${DRONE_STAGE_ARCH}
+      build_args_from_env:
+        - ARCH
       repo: mazzolino/restic
       username:
         from_secret: docker_username
@@ -30,9 +32,11 @@ steps:
 
   - name: build branch
     image: plugins/docker
+    environment:
+      ARCH: amd64
     settings:
-      build_args:
-        ARCH: ${DRONE_STAGE_ARCH}     
+      build_args_from_env:
+        - ARCH
       repo: mazzolino/restic-test
       tags: ${DRONE_BRANCH}-amd64
       username:
@@ -50,9 +54,11 @@ steps:
 
   - name: build pr
     image: plugins/docker
+    environment:
+      ARCH: amd64
     settings:
-      build_args:
-        ARCH: ${DRONE_STAGE_ARCH}   
+      build_args_from_env:
+        - ARCH
       repo: mazzolino/restic-test
       tags: pr-${DRONE_PULL_REQUEST}-amd64
       username:
@@ -74,9 +80,11 @@ platform:
 steps:
   - name: build release
     image: plugins/docker:linux-arm
+    environment:
+      ARCH: arm
     settings:
-      build_args:
-        ARCH: ${DRONE_STAGE_ARCH}
+      build_args_from_env:
+        - ARCH
       auto_tag: true
       auto_tag_suffix: arm
       repo: mazzolino/restic
@@ -95,9 +103,11 @@ steps:
 
   - name: build branch
     image: plugins/docker:linux-arm
+    environment:
+      ARCH: arm
     settings:
-      build_args:
-        ARCH: ${DRONE_STAGE_ARCH} 
+      build_args_from_env:
+        - ARCH
       repo: mazzolino/restic-test
       tags: ${DRONE_BRANCH}-arm
       username:
@@ -115,9 +125,11 @@ steps:
 
   - name: build pr
     image: plugins/docker:linux-arm
+    environment:
+      ARCH: arm
     settings:
-      build_args:
-        ARCH: ${DRONE_STAGE_ARCH}
+      build_args_from_env:
+        - ARCH
       repo: mazzolino/restic-test
       tags: pr-${DRONE_PULL_REQUEST}-arm
       username:
@@ -139,11 +151,13 @@ platform:
 steps:
   - name: build release
     image: plugins/docker:linux-arm64
+    environment:
+      ARCH: arm64
     settings:
       auto_tag: true
       auto_tag_suffix: arm64
-      build_args:
-        ARCH: ${DRONE_STAGE_ARCH} 
+      build_args_from_env:
+        - ARCH
       repo: mazzolino/restic
       username:
         from_secret: docker_username
@@ -160,9 +174,11 @@ steps:
 
   - name: build branch
     image: plugins/docker:linux-arm64
+    environment:
+      ARCH: arm64
     settings:
-      build_args:
-        ARCH: ${DRONE_STAGE_ARCH}
+      build_args_from_env:
+        - ARCH
       repo: mazzolino/restic-test
       tags: ${DRONE_BRANCH}-arm64
       username:
@@ -180,9 +196,11 @@ steps:
 
   - name: build pr
     image: plugins/docker:linux-arm64
+    environment:
+      ARCH: arm64
     settings:
-      build_args:
-        ARCH: ${DRONE_STAGE_ARCH}  
+      build_args_from_env:
+        - ARCH
       repo: mazzolino/restic-test
       tags: pr-${DRONE_PULL_REQUEST}-arm64
       username:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,27 +5,55 @@ FROM golang:1.15-alpine3.12 AS builder
 
 ARG ARCH
 
+
 ARG RESTIC_VERSION=0.12.0
+ARG RESTIC_SHA256_AMD64=63d13d53834ea8aa4d461f0bfe32a89c70ec47e239b91f029ed10bd88b8f4b80
+ARG RESTIC_SHA256_ARM=23c553049bbad7d777cd3b3d6065efa2edc2be13fd5eb1af15b43b6bfaf70bac
+ARG RESTIC_SHA256_ARM64=e60e06956a8e8cdcba7688b6cb9b9815ada2b025e87b94d717172c02b9aa6c91
+
 ARG RCLONE_VERSION=1.54.0
+# These are the checksums for the zip files
+ARG RCLONE_SHA256_AMD64=bee31ef4c9cfb1f2bcc3b662c3102cfbe6a551918d2deac6101459557a3fe0b4
+ARG RCLONE_SHA256_ARM=46a5d26f4dcb3d1e7d52cd2c26739782837d48dde9fb7a0255f9ccbfc1092e47
+ARG RCLONE_SHA256_ARM64=df7cb781f9310ee813100f683eed73260d4e235e6055b26cbddd798e29ae386f
 
 ARG GO_CRON_VERSION=0.0.4
 ARG GO_CRON_SHA256=6c8ac52637150e9c7ee88f43e29e158e96470a3aaa3fcf47fd33771a8a76d959
 
 RUN apk add --no-cache binutils-gold curl gcc musl-dev
 
-# Install restic from github
-RUN curl -sL --fail -o restic.bz2 https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_${ARCH}.bz2 \
+RUN case "$ARCH" in \
+  amd64 ) \
+    RESTIC_SHA256=$RESTIC_SHA256_AMD64 ; \
+    RCLONE_SHA256=$RCLONE_SHA256_AMD64 ; \
+    ;; \
+  arm ) \
+    RESTIC_SHA256=$RESTIC_SHA256_ARM ; \
+    RCLONE_SHA256=$RCLONE_SHA256_ARM ; \
+    ;; \
+  arm64 ) \
+    RESTIC_SHA256=$RESTIC_SHA256_ARM64 ; \
+    RCLONE_SHA256=$RCLONE_SHA256_ARM64 ; \
+    ;; \
+  *) \
+    echo unknown architecture ${ARCH} ; \
+    echit 1 ; \
+    ;; \
+ esac \
+ && curl -sL --fail -o restic.bz2 https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_${ARCH}.bz2 \
+ && echo "${RESTIC_SHA256}  restic.bz2" | sha256sum -c - \
  && bzip2 -d -v restic.bz2 \
  && mv restic /usr/local/bin/restic \
- && chmod +x /usr/local/bin/restic 
-
-# Install rclone from github
-RUN curl -sL --fail -o rclone.zip https://github.com/rclone/rclone/releases/download/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-${ARCH}.zip \
+ && chmod +x /usr/local/bin/restic \
+ && echo restic downloaded, verified and installed \
+ && curl -sL --fail -o rclone.zip https://github.com/rclone/rclone/releases/download/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-${ARCH}.zip \
+ && echo "${RCLONE_SHA256}  rclone.zip" | sha256sum -c - \
  && unzip rclone.zip \
  && mv rclone-v${RCLONE_VERSION}-linux-${ARCH}/rclone /usr/local/bin/rclone \
  && chmod +x /usr/local/bin/rclone \
  && rm -rf rclone-v${RCLONE_VERSION}-linux-${ARCH} \
- && rm rclone.zip
+ && rm rclone.zip \
+ && echo rclone downloaded, verified and installed
 
 RUN curl -sL -o go-cron.tar.gz https://github.com/djmaze/go-cron/archive/v${GO_CRON_VERSION}.tar.gz \
  && echo "${GO_CRON_SHA256}  go-cron.tar.gz" | sha256sum -c - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ FROM golang:1.15-alpine3.12 AS builder
 
 ARG ARCH
 
-
 ARG RESTIC_VERSION=0.12.0
 ARG RESTIC_SHA256_AMD64=63d13d53834ea8aa4d461f0bfe32a89c70ec47e239b91f029ed10bd88b8f4b80
 ARG RESTIC_SHA256_ARM=23c553049bbad7d777cd3b3d6065efa2edc2be13fd5eb1af15b43b6bfaf70bac
@@ -24,36 +23,36 @@ RUN apk add --no-cache binutils-gold curl gcc musl-dev
 
 RUN case "$ARCH" in \
   amd64 ) \
-    RESTIC_SHA256=$RESTIC_SHA256_AMD64 ; \
-    RCLONE_SHA256=$RCLONE_SHA256_AMD64 ; \
+    echo "${RESTIC_SHA256_AMD64}" > RESTIC_SHA256 ; \
+    echo "${RCLONE_SHA256_AMD64}" > RCLONE_SHA256 ; \
     ;; \
   arm ) \
-    RESTIC_SHA256=$RESTIC_SHA256_ARM ; \
-    RCLONE_SHA256=$RCLONE_SHA256_ARM ; \
+    echo "${RESTIC_SHA256_ARM}" > RESTIC_SHA256 ; \
+    echo "${RCLONE_SHA256_ARM}" > RCLONE_SHA256 ; \
     ;; \
   arm64 ) \
-    RESTIC_SHA256=$RESTIC_SHA256_ARM64 ; \
-    RCLONE_SHA256=$RCLONE_SHA256_ARM64 ; \
+    echo "${RESTIC_SHA256_ARM64}" > RESTIC_SHA256 ; \
+    echo "${RCLONE_SHA256_ARM64}" > RCLONE_SHA256 ; \
     ;; \
   *) \
-    echo unknown architecture ${ARCH} ; \
-    echit 1 ; \
+    echo "unknown architecture '${ARCH}'" ; \
+    exit 1 ; \
     ;; \
- esac \
- && curl -sL --fail -o restic.bz2 https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_${ARCH}.bz2 \
- && echo "${RESTIC_SHA256}  restic.bz2" | sha256sum -c - \
+ esac
+
+RUN curl -sL --fail -o restic.bz2 https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_${ARCH}.bz2 \
+ && echo "$(cat RESTIC_SHA256)  restic.bz2" | sha256sum -c - \
  && bzip2 -d -v restic.bz2 \
  && mv restic /usr/local/bin/restic \
- && chmod +x /usr/local/bin/restic \
- && echo restic downloaded, verified and installed \
- && curl -sL --fail -o rclone.zip https://github.com/rclone/rclone/releases/download/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-${ARCH}.zip \
- && echo "${RCLONE_SHA256}  rclone.zip" | sha256sum -c - \
+ && chmod +x /usr/local/bin/restic
+
+ RUN curl -sL --fail -o rclone.zip https://github.com/rclone/rclone/releases/download/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-${ARCH}.zip \
+ && echo "$(cat RCLONE_SHA256)  rclone.zip" | sha256sum -c - \
  && unzip rclone.zip \
  && mv rclone-v${RCLONE_VERSION}-linux-${ARCH}/rclone /usr/local/bin/rclone \
  && chmod +x /usr/local/bin/rclone \
  && rm -rf rclone-v${RCLONE_VERSION}-linux-${ARCH} \
- && rm rclone.zip \
- && echo rclone downloaded, verified and installed
+ && rm rclone.zip
 
 RUN curl -sL -o go-cron.tar.gz https://github.com/djmaze/go-cron/archive/v${GO_CRON_VERSION}.tar.gz \
  && echo "${GO_CRON_SHA256}  go-cron.tar.gz" | sha256sum -c - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,29 @@
 #
 FROM golang:1.15-alpine3.12 AS builder
 
+ARG ARCH
+
 ARG RESTIC_VERSION=0.12.0
-ARG RESTIC_SHA256=39b615a36a5082209a049cce188f0654c6435f0bc4178b7663672334594f10fe
+ARG RCLONE_VERSION=1.54.0
+
 ARG GO_CRON_VERSION=0.0.4
 ARG GO_CRON_SHA256=6c8ac52637150e9c7ee88f43e29e158e96470a3aaa3fcf47fd33771a8a76d959
-ARG RCLONE_VERSION=1.54.0
-ARG RCLONE_SHA256=95f952dc059b842bd40338458b77657f7b5a1680c4ca837a3adcf83b63c8fda1
 
 RUN apk add --no-cache binutils-gold curl gcc musl-dev
+
+# Install restic from github
+RUN curl -sL --fail -o restic.bz2 https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_${ARCH}.bz2 \
+ && bzip2 -d -v restic.bz2 \
+ && mv restic /usr/local/bin/restic \
+ && chmod +x /usr/local/bin/restic 
+
+# Install rclone from github
+RUN curl -sL --fail -o rclone.zip https://github.com/rclone/rclone/releases/download/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-${ARCH}.zip \
+ && unzip rclone.zip \
+ && mv rclone-v${RCLONE_VERSION}-linux-${ARCH}/rclone /usr/local/bin/rclone \
+ && chmod +x /usr/local/bin/rclone \
+ && rm -rf rclone-v${RCLONE_VERSION}-linux-${ARCH} \
+ && rm rclone.zip
 
 RUN curl -sL -o go-cron.tar.gz https://github.com/djmaze/go-cron/archive/v${GO_CRON_VERSION}.tar.gz \
  && echo "${GO_CRON_SHA256}  go-cron.tar.gz" | sha256sum -c - \
@@ -21,23 +36,6 @@ RUN curl -sL -o go-cron.tar.gz https://github.com/djmaze/go-cron/archive/v${GO_C
  && cd .. \
  && rm go-cron.tar.gz go-cron-${GO_CRON_VERSION} -fR
 
-RUN curl -sL -o rclone.tar.gz https://github.com/rclone/rclone/releases/download/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}.tar.gz \
- && echo "${RCLONE_SHA256}  rclone.tar.gz" | sha256sum -c - \
- && tar xzf rclone.tar.gz \
- && cd rclone-v${RCLONE_VERSION} \
- && CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' . \
- && mv rclone /usr/local/bin/rclone \
- && cd .. \
- && rm rclone.tar.gz rclone-v${RCLONE_VERSION} -fR
-
-RUN curl -sL -o restic.tar.gz https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic-${RESTIC_VERSION}.tar.gz \
- && echo "${RESTIC_SHA256}  restic.tar.gz" | sha256sum -c - \
- && tar xzf restic.tar.gz \
- && cd restic-${RESTIC_VERSION} \
- && go run build.go \
- && mv restic /usr/local/bin/restic \
- && cd .. \
- && rm restic.tar.gz restic-${RESTIC_VERSION} -fR
 
 #
 # Final image

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ARCH=amd64
 default: image push manifest
 
 image:
-		docker build -t ${IMAGE}:${ARCH} .
+		docker build -t ${IMAGE}:${ARCH} --build-arg ARCH=${ARCH} .
 
 push: image
 		docker push ${IMAGE}:${ARCH}


### PR DESCRIPTION
Download prebuilt binaries for restic andrclone from github. 

Changes:
 - Use build argumet arch to download binaries from github, no longer build restic and rclone in `Dockerfile`
 - Pass ARCH to docker build im `Makefile`
 - Pass architecture to docker build in `.drone.yml`.

Question:
It looks like one could change `RUN apk add --no-cache binutils-gold curl gcc musl-dev` to `RUN apk add --no-cache curl` in Dockerfile. Can anyone with mor go knowledge than me confirm please?