### PR TITLE
Enable ssh key auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ secrets:
     file: ./rclone.conf
 ```
 
+### Using `sftp` repository type
+
+In order to use the `sftp` repository type, you need to prepare a `.ssh` directory with your private ssh key(s), `known_hosts` (and an optional `config` file) and mount it inside the container at `/run/secrets/.ssh`.
+
+Example for Docker Compose:
+
+```yaml
+services:
+  backup:
+    # ...
+    volumes:
+      - ./.ssh:/run/secrets/.ssh:ro
+```
 
 ## Execute commands prior to backup
 
@@ -147,8 +160,8 @@ The commands specified are executed one by one.
 The Resticker docker image does not contain any tools for sending notifications, apart from `curl`. You should thus connect a second container for that purpose. For example, this is how mail notifications can be sent using [apprise-microservice](https://github.com/djmaze/apprise-microservice):
 
 ```yaml
-services:              
-  app:       
+services:
+  app:
     image: mazzolino/restic:1.1
     environment:
       # ...

--- a/entrypoint
+++ b/entrypoint
@@ -8,6 +8,15 @@ if [[ -f "$RCLONE_CONFIG_PATH" ]]; then
   cp "$RCLONE_CONFIG_PATH" /root/.config/rclone/rclone.conf
 fi
 
+SSH_CONFIG_PATH="/run/secrets/.ssh"
+
+if [[ -d "$SSH_CONFIG_PATH" ]]; then
+  mkdir -p /root/.ssh
+  chmod 700 /root/.ssh
+  cp -r "${SSH_CONFIG_PATH}"/* /root/.ssh
+  chmod -R u+rwX,go-rwx /root/.ssh
+fi
+
 echo "Checking configured repository '${RESTIC_REPOSITORY}' ..."
 if restic cat config > /dev/null; then
   echo "Repository found."


### PR DESCRIPTION
When using an repository typ  `sftp` one needs to provide the private keys to restic.
This change allows mounting a `.ssh` directory into the container.
