### PR TITLE
Fix #105: No more zombies by using proper init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN curl -sL -o go-cron.tar.gz https://github.com/djmaze/go-cron/archive/v${GO_C
 #
 FROM alpine:3.14
 
-RUN apk add --update --no-cache ca-certificates fuse nfs-utils openssh tzdata bash curl docker-cli gzip
+RUN apk add --update --no-cache ca-certificates fuse nfs-utils openssh tzdata bash curl docker-cli gzip tini
 
 ENV RESTIC_REPOSITORY /mnt/restic
 
@@ -77,4 +77,4 @@ COPY --from=builder /usr/local/bin/* /usr/local/bin/
 COPY backup prune check /usr/local/bin/
 COPY entrypoint /
 
-ENTRYPOINT ["/entrypoint"]
+ENTRYPOINT ["/sbin/tini", "--", "/entrypoint"]


### PR DESCRIPTION
Proper reaping of zombie processes by using /tini as init process.

Fixes Issue #105