### PR TITLE
Prevent failure hook being called when restic returns -3

### DIFF
--- a/backup
+++ b/backup
@@ -55,7 +55,7 @@ rc=$?
 set -e
 
 if [ $rc -ne 0 ]; then
-  if [ $rc -eq 3 ] && [ -n "${POST_COMMANDS_INCOMPLETE:-}" ]; then
+  if [ $rc -eq 3 ]; then
   	run_commands "${POST_COMMANDS_INCOMPLETE:-}"
   else
   	run_commands "${POST_COMMANDS_FAILURE:-}"


### PR DESCRIPTION
(file missing but backup completed) and no "incomplete" hook defined