### PR TITLE
Update example docker compose so services restart on crash

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -4,7 +4,7 @@ services:
   backup:
     image: mazzolino/restic
     hostname: docker
-    restart: always
+    restart: unless-stopped
     environment:
       RUN_ON_STARTUP: "true"
       BACKUP_CRON: "0 30 3 * * *"
@@ -30,7 +30,7 @@ services:
   prune:
     image: mazzolino/restic
     hostname: docker
-    restart: always
+    restart: unless-stopped
     environment:
       RUN_ON_STARTUP: "true"
       PRUNE_CRON: "0 0 4 * * *"
@@ -43,7 +43,7 @@ services:
   check:
     image: mazzolino/restic
     hostname: docker
-    restart: always
+    restart: unless-stopped
     environment:
       RUN_ON_STARTUP: "false"
       CHECK_CRON: "0 15 5 * * *"

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -4,6 +4,7 @@ services:
   backup:
     image: mazzolino/restic
     hostname: docker
+    restart: always
     environment:
       RUN_ON_STARTUP: "true"
       BACKUP_CRON: "0 30 3 * * *"
@@ -29,6 +30,7 @@ services:
   prune:
     image: mazzolino/restic
     hostname: docker
+    restart: always
     environment:
       RUN_ON_STARTUP: "true"
       PRUNE_CRON: "0 0 4 * * *"
@@ -41,6 +43,7 @@ services:
   check:
     image: mazzolino/restic
     hostname: docker
+    restart: always
     environment:
       RUN_ON_STARTUP: "false"
       CHECK_CRON: "0 15 5 * * *"


### PR DESCRIPTION
Restic backup can fail for a number of reasons. If the process crashes once, it should be restarted, so once the underlying failure is resolved (B2 API downtime, internet connectivity issues, etc) backups will resume automatically.