### PR TITLE
Update example Swarm file

### DIFF
--- a/docker-swarm.example.yml
+++ b/docker-swarm.example.yml
@@ -10,7 +10,6 @@ services:
       RESTIC_BACKUP_SOURCES: /mnt/volumes
       #RESTIC_BACKUP_ARGS: -v
       RESTIC_BACKUP_TAGS: docker-volumes
-      RESTIC_FORGET_ARGS: --prune --keep-last 14 --keep-daily 1
       B2_ACCOUNT_ID: xxxxxxx
       B2_ACCOUNT_KEY: yyyyyyyy
       TZ: Europe/Berlin
@@ -25,6 +24,7 @@ services:
     hostname: docker
     environment:
       PRUNE_CRON: "0 0 4 * * *"
+      RESTIC_FORGET_ARGS: --prune --keep-last 14 --keep-daily 1
       RESTIC_REPOSITORY: b2:my-repo:/restic
       RESTIC_PASSWORD: supersecret
       B2_ACCOUNT_ID: xxxxxxx


### PR DESCRIPTION
Move the `RESTIC_FORGET_ARGS` to a more sensible location for Swarm clusters.

Related to #153.