### PR TITLE
#184: Fix copying contents of $ssh_config_path into /root/.ssh

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -11,7 +11,7 @@ fi
 SSH_CONFIG_PATH="/run/secrets/.ssh"
 
 if [[ -d "$SSH_CONFIG_PATH" ]]; then
-  cp -r "${SSH_CONFIG_PATH}" /root/.ssh
+  cp -r "${SSH_CONFIG_PATH}/." /root/.ssh
   chmod 700 /root/.ssh
   chmod -R u+rwX,go-rwx /root/.ssh
 fi


### PR DESCRIPTION
Fixes #184 