### PR TITLE
allow escaping of multiple spaces

### DIFF
--- a/backup
+++ b/backup
@@ -13,11 +13,11 @@ function run_exit_commands {
 }
 
 function replace_spaces {
-  echo "${1/\\ /\\}"
+  echo "${1//\\ /\\}"
 }
 
 function replace_spaces_back {
-  echo "${1/\\/ }"
+  echo "${1//\\/ }"
 }
 
 function check_bool {


### PR DESCRIPTION
Fix bash string replacing, so all spaces are replaced and not only the first.
https://stackoverflow.com/a/13210909

This allows e.g. to set rclone option:
```yaml
services:
  resticker-backup:
    image: mazzolino/restic:pr-192@sha256:7378ddc7f505c6d3035e9e1ddc13a26f63aed7b2c9d6bb90b2b5bb0f1d938344
    environment:
      RESTIC_BACKUP_ARGS: >-
        -o rclone.program=ssh\ -p23\ user@example.com\ forced-command
        --verbose=2
[...]
```