### PR TITLE
Add renovate.json to automate Dockerfile dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": ["ARG RESTIC_VERSION=(?<currentValue>.*)"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "restic/restic",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v(?<version>.*)$",
+      "currentValueTemplate": "{{ currentValue }}"
+    },
+    {
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": ["ARG RCLONE_VERSION=(?<currentValue>.*)"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "rclone/rclone",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v(?<version>.*)$",
+      "currentValueTemplate": "{{ currentValue }}"
+    }
+  ]
+}


### PR DESCRIPTION
Continuing from https://github.com/djmaze/resticker/pull/198:

Renovate can be configured to detect the version numbers in the Dockerfile, but I couldn't get the hashes to update. But perhaps that's sufficient as a ping to update them manually.

Relevant PRs from renovatebot in my fork:
restic: https://github.com/cz3k/resticker/pull/5
rclone: https://github.com/cz3k/resticker/pull/4