### PR TITLE
Skip backup if already running

### DIFF
--- a/backup
+++ b/backup
@@ -32,6 +32,14 @@ function check_bool {
   echo "false"
 }
 
+BACKUP_RUNNING="${BACKUP_RUNNING:-false}"
+if [ "$BACKUP_RUNNING" = "true" ]; then
+  echo Backup already running, exiting gracefully
+  exit 0
+fi
+
+export BACKUP_RUNNING=true
+
 trap run_exit_commands EXIT
 
 run_commands "${PRE_COMMANDS:-}"
@@ -109,5 +117,7 @@ incomplete)
 failure)
   run_commands "${POST_COMMANDS_FAILURE:-}";;
 esac
+
+export BACKUP_RUNNING=false
 
 exit $rc

--- a/backup
+++ b/backup
@@ -33,12 +33,12 @@ function check_bool {
 }
 
 # Check if another backup is running
-if [ -f /usr/backup.lock ]; then
+if [ -f /run/lock/backup.lock ]; then
   echo Backup already running, skipping backup at $(date +"%Y-%m-%d %H:%M:%S")
   exit 1
 fi
 
-touch /usr/backup.lock
+touch /run/lock/backup.lock
 
 trap run_exit_commands EXIT
 
@@ -118,6 +118,6 @@ failure)
   run_commands "${POST_COMMANDS_FAILURE:-}";;
 esac
 
-rm -f /usr/backup.lock
+rm -f /run/lock/backup.lock
 
 exit $rc

--- a/backup
+++ b/backup
@@ -32,13 +32,13 @@ function check_bool {
   echo "false"
 }
 
-BACKUP_RUNNING="${BACKUP_RUNNING:-false}"
-if [ "$BACKUP_RUNNING" = "true" ]; then
-  echo -e "Backup already running, exiting gracefully"
-  exit 0
+# Check if another backup is running
+if [ -f /usr/backup.lock ]; then
+  echo Backup already running, skipping backup at $(date +"%Y-%m-%d %H:%M:%S")
+  exit 1
 fi
 
-export BACKUP_RUNNING=true
+touch /usr/backup.lock
 
 trap run_exit_commands EXIT
 
@@ -118,6 +118,6 @@ failure)
   run_commands "${POST_COMMANDS_FAILURE:-}";;
 esac
 
-export BACKUP_RUNNING=false
+rm -f /usr/backup.lock
 
 exit $rc

--- a/backup
+++ b/backup
@@ -34,7 +34,7 @@ function check_bool {
 
 BACKUP_RUNNING="${BACKUP_RUNNING:-false}"
 if [ "$BACKUP_RUNNING" = "true" ]; then
-  echo Backup already running, exiting gracefully
+  echo -e "Backup already running, exiting gracefully"
   exit 0
 fi
 

--- a/entrypoint
+++ b/entrypoint
@@ -16,6 +16,8 @@ if [[ -d "$SSH_CONFIG_PATH" ]]; then
   chmod -R u+rwX,go-rwx /root/.ssh
 fi
 
+rm -f /usr/backup.lock
+
 command="${1-}"
 
 if [[ "$command" != "unlock" ]]; then

--- a/entrypoint
+++ b/entrypoint
@@ -16,7 +16,7 @@ if [[ -d "$SSH_CONFIG_PATH" ]]; then
   chmod -R u+rwX,go-rwx /root/.ssh
 fi
 
-rm -f /usr/backup.lock
+rm -f /run/lock/backup.lock
 
 command="${1-}"
 


### PR DESCRIPTION
Issue: #201 

The file `/usr/backup.lock` is used to keep track of is there any backup running, if it exits, the backup is skipped and the backup script will exit gracefully.

The pre-backup, post-backup and exit commands are not executed if the backup is skipped.