### PR TITLE
Prevent the container entrypoint script from exiting on any error

### DIFF
--- a/backup
+++ b/backup
@@ -99,7 +99,13 @@ esac
 if [ -n "${RESTIC_FORGET_ARGS}" ]; then
   IFS=" " read -r -a RESTIC_FORGET_ARGS <<< "$RESTIC_FORGET_ARGS"
   echo Forget about old snapshots based on RESTIC_FORGET_ARGS = "${RESTIC_FORGET_ARGS[@]}"
+  set +e
   restic forget "${tag_options[@]}" "${RESTIC_FORGET_ARGS[@]}"
+  forget_rc=$?
+  set -e
+  if [ $forget_rc -ne 0 ]; then
+      echo "Forget failed"
+  fi
 fi
 
 end=$(date +%s)

--- a/entrypoint
+++ b/entrypoint
@@ -63,7 +63,7 @@ else
   if [[ -n "${BACKUP_CRON:-}" ]]; then
     if [ "${RUN_ON_STARTUP:-}" == "true" ]; then
       echo "Executing backup on startup ..."
-      /usr/local/bin/backup
+      /usr/local/bin/backup || true
     fi
     echo "Scheduling backup job according to cron expression."
     exec go-cron "$BACKUP_CRON" /usr/local/bin/backup
@@ -71,7 +71,7 @@ else
   if [[ -n "${PRUNE_CRON:-}" ]]; then
     if [ "${RUN_ON_STARTUP:-}" == "true" ]; then
       echo "Executing prune job on startup ..."
-      /usr/local/bin/prune
+      /usr/local/bin/prune || true
     fi
     echo "Scheduling prune job according to cron expression."
     exec go-cron "$PRUNE_CRON" /usr/local/bin/prune
@@ -79,7 +79,7 @@ else
   if [[ -n "${CHECK_CRON:-}" ]]; then
     if [ "${RUN_ON_STARTUP:-}" == "true" ]; then
       echo "Executing check job on startup ..."
-      /usr/local/bin/check
+      /usr/local/bin/check || true
     fi
     echo "Scheduling check job according to cron expression."
     exec go-cron "$CHECK_CRON" /usr/local/bin/check


### PR DESCRIPTION
The initial run of `backup`, `prune` or `check` could lead to an error exit of the `entrypoint` script (and thus stop the container).

Also, the `forget` command could cause the same problem during any run.

refs #168
closes #190 