### PR TITLE
Feature/pre command failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ PRE_COMMANDS: |-
 ```
 
 The commands specified in `PRE_COMMANDS` are executed one by one.
+In case of a failure, `PRE_COMMANDS_FAILURE` will be executed, if set.
+And if `ABORT_ON_PRE_COMMANDS_FAILURE` is set to `"true"`, the backup will be aborted.
 
 ## Execute commands after backup
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ PRE_COMMANDS: |-
 
 The commands specified in `PRE_COMMANDS` are executed one by one.
 In case of a failure, `PRE_COMMANDS_FAILURE` will be executed, if set.
-And if `ABORT_ON_PRE_COMMANDS_FAILURE` is set to `"true"`, the backup will be aborted.
+The backup will be aborted if `ABORT_ON_PRE_COMMANDS_FAILURE` is set to `"true"`.
 
 ## Execute commands after backup
 

--- a/backup
+++ b/backup
@@ -49,7 +49,19 @@ touch /run/lock/backup.lock
 
 trap run_exit_commands EXIT
 
+set +e
 run_commands "${PRE_COMMANDS:-}"
+pre_result=$?
+set -e
+if [ $pre_result -ne 0 ]; then
+  echo "Warning: At least one command of PRE_COMMANDS exited with a non-zero exit code."
+  run_commands "${PRE_COMMANDS_FAILURE:-}"
+
+  if [ "${ABORT_ON_PRE_COMMANDS_FAILURE:-}" == "true" ]; then
+    rm -f /run/lock/backup.lock
+    exit 1
+  fi
+fi
 
 IFS=" " read -r -a RESTIC_BACKUP_SOURCES <<< "$(replace_spaces "${RESTIC_BACKUP_SOURCES:-/data}")"
 RESTIC_BACKUP_TAGS="${RESTIC_BACKUP_TAGS:-}"

--- a/backup
+++ b/backup
@@ -2,8 +2,15 @@
 set -eo pipefail
 
 function run_commands {
-	COMMANDS=$1
-	while IFS= read -r cmd; do echo "$cmd" && eval "$cmd" ; done < <(printf '%s\n' "$COMMANDS")
+  COMMANDS=$1
+  RESULT=0
+  while IFS= read -r cmd; do
+    echo "$cmd" && eval "$cmd"
+    if [ $? -ne 0 ]; then
+      RESULT=1
+    fi
+  done < <(printf '%s\n' "$COMMANDS")
+  return $RESULT
 }
 
 function run_exit_commands {

--- a/check
+++ b/check
@@ -2,8 +2,15 @@
 set -euo pipefail
 
 function run_commands {
-	COMMANDS=$1
-	while IFS= read -r cmd; do echo $cmd && eval $cmd ; done < <(printf '%s\n' "$COMMANDS")
+  COMMANDS=$1
+  RESULT=0
+  while IFS= read -r cmd; do
+    echo "$cmd" && eval "$cmd"
+    if [ $? -ne 0 ]; then
+      RESULT=1
+    fi
+  done < <(printf '%s\n' "$COMMANDS")
+  return $RESULT
 }
 
 function run_exit_commands {
@@ -13,7 +20,18 @@ function run_exit_commands {
 }
 
 main() {
+  set +e
   run_commands "${PRE_COMMANDS:-}"
+  pre_result=$?
+  set -e
+  if [ $pre_result -ne 0 ]; then
+    echo "Warning: At least one command of PRE_COMMANDS exited with a non-zero exit code."
+    run_commands "${PRE_COMMANDS_FAILURE:-}"
+
+    if [ "${ABORT_ON_PRE_COMMANDS_FAILURE:-}" == "true" ]; then
+      exit 1
+    fi
+  fi
 
   start=$(date +%s)
   echo Starting check at "$(date +"%Y-%m-%d %H:%M:%S")"

--- a/prune
+++ b/prune
@@ -2,8 +2,15 @@
 set -euo pipefail
 
 function run_commands {
-	COMMANDS=$1
-	while IFS= read -r cmd; do echo $cmd && eval $cmd ; done < <(printf '%s\n' "$COMMANDS")
+  COMMANDS=$1
+  RESULT=0
+  while IFS= read -r cmd; do
+    echo "$cmd" && eval "$cmd"
+    if [ $? -ne 0 ]; then
+      RESULT=1
+    fi
+  done < <(printf '%s\n' "$COMMANDS")
+  return $RESULT
 }
 
 function run_exit_commands {
@@ -13,7 +20,18 @@ function run_exit_commands {
 }
 
 main() {
+  set +e
   run_commands "${PRE_COMMANDS:-}"
+  pre_result=$?
+  set -e
+  if [ $pre_result -ne 0 ]; then
+    echo "Warning: At least one command of PRE_COMMANDS exited with a non-zero exit code."
+    run_commands "${PRE_COMMANDS_FAILURE:-}"
+
+    if [ "${ABORT_ON_PRE_COMMANDS_FAILURE:-}" == "true" ]; then
+      exit 1
+    fi
+  fi
 
   start=$(date +%s)
 


### PR DESCRIPTION
I just found, that my backups did not notify me of a failure (`POST_COMMANDS_FAILURE`) as the `PRE_COMMANDS` script was the one failing. Luckily the part failing was not crucial for the actual data to be backed up but still bad enough.

This PR is an attempt, to avoid that issue for the future. It adds  `PRE_COMMANDS_FAILURE` and `ABORT_ON_PRE_COMMANDS_FAILURE`.

- `PRE_COMMANDS_FAILURE` allows to define commands to execute in case of an non-zero exit of `PRE_COMMANDS`. To Achieve that, I modified the `run_commands` helper, to return a non-zero exit code, when any of the pre commands fails.
- `ABORT_ON_PRE_COMMANDS_FAILURE` can be set to "true" to fail (exit 1) the whole backup when the pre commands failed.

I added this to `backup` as well as `prune` and `check`.

I opted against re-using `POST_COMMANDS_FAILURE`, to avoid unexpected behaviour for users upgrading.

Fixes https://github.com/djmaze/resticker/issues/91